### PR TITLE
fix: secure burn endpoint and correct start script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.env
+

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "nursecredx-backend",
   "version": "1.0.0",
   "description": "Back-end for NursecredX NFT application",
-  "main": "serverjs",
+  "main": "server.js",
   "scripts": {
-    "start": "node serverjs"
+    "start": "node server.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/server.js
+++ b/server.js
@@ -67,7 +67,7 @@ app.get('/nfts', async (req, res) => {
   }
 });
 
-app.post('/burn', async (req, res) => {
+app.post('/burn', requireApiKey, async (req, res) => {
   const { tokenId } = req.body;
   try {
     const client = await connectClient();


### PR DESCRIPTION
## Summary
- protect NFT burn endpoint with API key middleware
- point start script to server.js entry
- ignore local env and modules

## Testing
- `npm test` (fails: Missing script: "test")
- `node server.js` (Server running on port 4000)


------
https://chatgpt.com/codex/tasks/task_e_68ae5b9fb7b4832187cc6249a92fdb6a